### PR TITLE
fix hello app build in gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -13,7 +13,7 @@ github:
 
 # List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
 tasks:
-  - init: docker-compose -f run-with-collector.yaml --build pull
+  - init: docker-compose -f run-with-collector.yaml build && docker-compose -f run-with-collector.yaml pull
     command: docker-compose -f run-with-collector.yaml up -d
 
 # List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/


### PR DESCRIPTION
Oops my last PR didn't correctly build the hello app in the prebuild. By the way, you can enable prebuilds so the images are already built and pulled before the user opens the workspace. You download the gitpod app inside your github account like this: https://www.gitpod.io/docs/prebuilds#enable-prebuilt-workspaces

For example, this workspace from my fork will have all the images prebuilt and pulled, and the services start on launch:
- https://gitpod.io/#https://github.com/chuck-confluent/otel-with-java/